### PR TITLE
Block until server is started before returning the response; add to e…

### DIFF
--- a/src/main/scala/ly/stealth/mesos/exhibitor/ExhibitorServer.scala
+++ b/src/main/scala/ly/stealth/mesos/exhibitor/ExhibitorServer.scala
@@ -29,6 +29,7 @@ import play.api.libs.json.{JsValue, Json, Writes, _}
 
 import scala.collection.JavaConversions._
 import scala.collection.mutable
+import scala.concurrent.duration.Duration
 
 case class TaskConfig(exhibitorConfig: mutable.Map[String, String], sharedConfigOverride: mutable.Map[String, String], id: String, var hostname: String = "", var sharedConfigChangeBackoff: Long = 10000, var cpus: Double = 0.2, var mem: Double = 256, var ports: List[Range] = Nil)
 
@@ -115,6 +116,17 @@ case class ExhibitorServer(id: String) {
     }
 
     None
+  }
+
+  def waitFor(state: ExhibitorServer.State, timeout: Duration): Boolean = {
+    var t = timeout.toMillis
+    while (t > 0 && this.state != state) {
+      val delay = Math.min(100, t)
+      Thread.sleep(delay)
+      t -= delay
+    }
+
+    this.state == state
   }
 
   private[exhibitor] def newExecutor(id: String): ExecutorInfo = {

--- a/src/main/scala/ly/stealth/mesos/exhibitor/Scheduler.scala
+++ b/src/main/scala/ly/stealth/mesos/exhibitor/Scheduler.scala
@@ -140,7 +140,11 @@ object Scheduler extends org.apache.mesos.Scheduler {
 
     status.getState match {
       case TaskState.TASK_RUNNING =>
-        onServerStarted(server, driver, status)
+        new Thread {
+          override def run() {
+            onServerStarted(server, driver, status)
+          }
+        }.start()
       case TaskState.TASK_LOST | TaskState.TASK_FAILED | TaskState.TASK_ERROR =>
         onServerFailed(server, status)
       case TaskState.TASK_FINISHED | TaskState.TASK_KILLED => logger.info(s"Task ${status.getTaskId.getValue} has finished")
@@ -154,8 +158,8 @@ object Scheduler extends org.apache.mesos.Scheduler {
         this.synchronized {
           if (server.state != ExhibitorServer.Running) {
             logger.info(s"Adding server ${server.id} to ensemble")
-            addToEnsemble(server)
             server.state = ExhibitorServer.Running
+            addToEnsemble(server)
           }
         }
       case None =>

--- a/src/main/test/ly/stealth/mesos/exhibitor/HttpServerTest.scala
+++ b/src/main/test/ly/stealth/mesos/exhibitor/HttpServerTest.scala
@@ -104,9 +104,9 @@ class HttpServerTest extends MesosTestCase {
   def startStopServer() {
     sendRequest("/add", parseMap("id=0"))
 
-    val startResponse = sendRequest("/start", parseMap("id=0")).as[ApiResponse]
+    val startResponse = sendRequest("/start", parseMap("id=0,timeout=0ms")).as[ApiResponse]
     assertTrue(startResponse.success)
-    assertTrue(startResponse.message.contains("Started servers"))
+    assertTrue(startResponse.message.contains("scheduled"))
     assertNotEquals(None, startResponse.value)
     assertEquals(ExhibitorServer.Stopped, startResponse.value.get.servers.head.state)
 


### PR DESCRIPTION
…nsemble on a thread to release unused resources

Fixes #4, #6 and probably #7 
