### PR TITLE
Generic constraints concept

### DIFF
--- a/src/main/scala/ly/stealth/mesos/exhibitor/Scheduler.scala
+++ b/src/main/scala/ly/stealth/mesos/exhibitor/Scheduler.scala
@@ -14,7 +14,7 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 import scala.util.{Failure, Success, Try}
 
-object Scheduler extends org.apache.mesos.Scheduler {
+object Scheduler extends org.apache.mesos.Scheduler with Constraints[ExhibitorServer] {
   private val logger = Logger.getLogger(this.getClass)
 
   private[exhibitor] val cluster = Cluster()
@@ -101,6 +101,8 @@ object Scheduler extends org.apache.mesos.Scheduler {
     logger.info("[executorLost] executor:" + Str.id(executorId.getValue) + " slave:" + Str.id(slaveId.getValue) + " status:" + status)
   }
 
+  override def tasks: Traversable[ExhibitorServer] = cluster.servers
+
   private def onResourceOffers(offers: List[Offer]) {
     offers.foreach { offer =>
       acceptOffer(offer).foreach { declineReason =>
@@ -118,12 +120,12 @@ object Scheduler extends org.apache.mesos.Scheduler {
       case Nil => Some("all servers are running")
       case servers =>
         val reason = servers.flatMap { server =>
-          server.matches(offer, otherTasksAttributes) match {
+          checkConstraints(offer, server).orElse(server.matches(offer) match {
             case Some(declineReason) => Some(s"server ${server.id}: $declineReason")
             case None =>
               launchTask(server, offer)
               return None
-          }
+          })
         }.mkString(", ")
 
         if (reason.isEmpty) None else Some(reason)
@@ -294,15 +296,6 @@ object Scheduler extends org.apache.mesos.Scheduler {
     }
 
     tryGetConfig(retries, 1000)
-  }
-
-  private[exhibitor] def otherTasksAttributes(name: String): List[String] = {
-    def value(server: ExhibitorServer, name: String): Option[String] = {
-      if (name == "hostname") Option(server.config.hostname)
-      else server.task.attributes.get(name)
-    }
-
-    cluster.servers.filter(_.task != null).flatMap(value(_, name)).toList
   }
 
   private[exhibitor] val RECONCILE_DELAY = 10 seconds

--- a/src/main/test/ly/stealth/mesos/exhibitor/ExhibitorServerTest.scala
+++ b/src/main/test/ly/stealth/mesos/exhibitor/ExhibitorServerTest.scala
@@ -55,56 +55,6 @@ class ExhibitorServerTest extends MesosTestCase {
   }
 
   @Test
-  def matchesHostname() {
-    assertEquals(None, server.matches(offer(hostname = "master")))
-    assertEquals(None, server.matches(offer(hostname = "slave0")))
-
-    // like
-    server.constraints.clear()
-    server.constraints += "hostname" -> List(Constraint("like:master"))
-    assertEquals(None, server.matches(offer(hostname = "master")))
-    assertEquals(Some("hostname doesn't match like:master"), server.matches(offer(hostname = "slave0")))
-
-    server.constraints.clear()
-    server.constraints += "hostname" -> List(Constraint("like:master.*"))
-    assertEquals(None, server.matches(offer(hostname = "master")))
-    assertEquals(None, server.matches(offer(hostname = "master-2")))
-    assertEquals(Some("hostname doesn't match like:master.*"), server.matches(offer(hostname = "slave0")))
-
-    // unique
-    server.constraints.clear()
-    server.constraints += "hostname" -> List(Constraint("unique"))
-    assertEquals(None, server.matches(offer(hostname = "master")))
-    assertEquals(Some("hostname doesn't match unique"), server.matches(offer(hostname = "master"), _ => List("master")))
-    assertEquals(None, server.matches(offer(hostname = "master"), _ => List("slave0")))
-
-    // multiple
-    server.constraints.clear()
-    server.constraints += "hostname" -> List(Constraint("unique"), Constraint("like:slave.*"))
-    assertEquals(None, server.matches(offer(hostname = "slave0")))
-    assertEquals(Some("hostname doesn't match unique"), server.matches(offer(hostname = "slave0"), _ => List("slave0")))
-    assertEquals(Some("hostname doesn't match like:slave.*"), server.matches(offer(hostname = "master")))
-    assertEquals(None, server.matches(offer(hostname = "slave0"), _ => List("master")))
-  }
-
-  @Test
-  def matchesAttributes() {
-    // like
-    server.constraints.clear()
-    server.constraints += "rack" -> List(Constraint("like:1-.*"))
-    assertEquals(None, server.matches(offer(attributes = "rack=1-1")))
-    assertEquals(None, server.matches(offer(attributes = "rack=1-2")))
-    assertEquals(Some("rack doesn't match like:1-.*"), server.matches(offer(attributes = "rack=2-1")))
-
-    // unique
-    server.constraints.clear()
-    server.constraints += "floor" -> List(Constraint("unique"))
-    assertEquals(None, server.matches(offer(attributes = "rack=1-1,floor=1")))
-    assertEquals(None, server.matches(offer(attributes = "rack=1-1,floor=1"), _ => List("2")))
-    assertEquals(Some("floor doesn't match unique"), server.matches(offer(attributes = "rack=1-1,floor=1"), _ => List("1")))
-  }
-
-  @Test
   def idFromTaskId() {
     assertEquals("0", ExhibitorServer.idFromTaskId(ExhibitorServer.nextTaskId("0")))
     assertEquals("100", ExhibitorServer.idFromTaskId(ExhibitorServer.nextTaskId("100")))


### PR DESCRIPTION
This is an attempt to place all generic constraint logic into one place to make it possible to integrate them into a framework with just a couple lines of code.

This PR introduces 2 new entities (and total of 3 - we already have Constraint type implemented).
`Constrained` is something that we want to constrain (e.g. Exhibitor server, Kafka server, any kind of task actually) and needs 2 methods to be implemented:
- constraints - should return a Map[String, List[Constraint]] where keys are attribute names and values are constraints associated with this attribute. For example if we want the hostname to be unique and like "slave0" the return would look like this: `Map("hostname" -> List(Constraint("unique"), Constraint("like:slave0")))`
- attribute(name) - should return this tasks attribute for a given name. E.g. if the task is running on host "slave0" then `attribute("hostname")` should return "slave0" for this task.

The second trait is `Constraints[T <: Constrained]` which needs one method to be implemented:
- tasks - should return a Traversable (which is a collection/iterable of any kind) of constrained tasks within this framework.

`Constraints` exposes one valuable method to use - `checkConstraints(offer, task)` which will decide whether the given constrained task matches the offer. The return of this method is an `Option[String]` which will contain a reason why the offer was declined (e.g. "hostname doesn't match unique" etc) or will be empty if the task matches the offer.

The basic usage would be like follows:

```
class Task(_constraints: Map[String, List[Constraint]], attributes: Map[String, String]) extends Constrained {
  override def constraints: Map[String, List[Constraint]] = _constraints

  override def attribute(name: String): Option[String] = attributes.get(name)
}

class Scheduler extends org.apache.mesos.Scheduler with Constraints[Task] {
  val _tasks = List(task1, task2 ...)

  override def tasks: Traversable[Task] = _tasks

  def acceptOffer(offer: Offer, task: Task) {
    val declineReason = checkConstraints(offer, task)
    if (declineReason.isEmpty) { //constraints are ok 
      ...
    }
  }
}
```

This PR also contains changes to this framework using this generalized constraint utils as well.

Potentially this could be moved to a separate utility library but first I'd want to hear your opinion on this @joestein @dmitrypekar 

Thanks
