### PR TITLE
fixed acceptors thread pool size.

### DIFF
--- a/src/main/scala/net/elodina/mesos/exhibitor/HttpServer.scala
+++ b/src/main/scala/net/elodina/mesos/exhibitor/HttpServer.scala
@@ -62,7 +62,7 @@ object HttpServer {
     if (server != null) throw new IllegalStateException("HttpServer already started")
     if (resolveDeps) this.resolveDeps()
 
-    val threadPool = new QueuedThreadPool(16)
+    val threadPool = new QueuedThreadPool(Runtime.getRuntime.availableProcessors() * 16)
     threadPool.setName("Jetty")
 
     server = new Server(threadPool)


### PR DESCRIPTION
the number of acceptor thread jetty was setting by default was based on number of processors. The thread pool was also default so the situation becomes only acceptor and no worker threads.
